### PR TITLE
Counting in arbitrary bases with arbitrary alphabets

### DIFF
--- a/page_numbering.tex
+++ b/page_numbering.tex
@@ -30,11 +30,16 @@
   \fi%
 }
 
+\newcommand*{\baseFive}[1]{\expandafter\@baseFive{\csname c@#1\endcsname}}
+\newcommand*{\@baseFive}[1]{\@basecount{arabic}{5}{\number #1}}
+
+\newcommand*{\basicSymb}[1]{\expandafter\@basicSymb{\csname c@#1\endcsname}}
+\newcommand*{\@basicSymb}[1]{\@basecount{simpleSymbols}{7}{\number #1}}
+\newcommand*{\@simpleSymbols}[1]{$\ifcase#1=\or+\or-\or\times\or\div\or<\or>\else\@ctrerr\fi$}
 
 \newcommand*{\greekX}[1]{%
   \expandafter\@greekX{\csname c@#1\endcsname}%
 }
-
 
 \newcommand*{\@greekX}[1]{%
   \@basecount{greek}{24}{\number #1}%

--- a/page_numbering.tex
+++ b/page_numbering.tex
@@ -4,8 +4,8 @@
   \ifnum #3 = 0%
     \csname @#1\endcsname{0}%
   \else%
-    \expandafter\edef\csname @baseResult\endcsname{\noexpand\@@basecount{#1}{#2}{#3}{}}%
-    \csname @baseResult\endcsname%
+    \edef\@baseResult{\noexpand\@@basecount{#1}{#2}{#3}{}}%
+    \@baseResult%
   \fi%
 }
 
@@ -24,8 +24,8 @@
     \multiply\@@baseM by\@@baseB%
     \@@baseR #3%
     \advance\@@baseR by-\@@baseM%
-    \expandafter\edef\csname @@baseNext\endcsname{\the\@@baseQ}%
-    \expandafter\edef\csname @@baseAcc\endcsname{\csname @#1\endcsname{\the\@@baseR}#4}%
+    \edef\@@baseNext{\the\@@baseQ}%
+    \edef\@@baseAcc{\csname @#1\endcsname{\the\@@baseR}#4}%
     \@@basecount{#1}{#2}{\@@baseNext}{\@@baseAcc}%
   \fi%
 }

--- a/page_numbering.tex
+++ b/page_numbering.tex
@@ -31,7 +31,7 @@
 }
 
 \newcommand*{\baseFive}[1]{\expandafter\@baseFive{\csname c@#1\endcsname}}
-\newcommand*{\@baseFive}[1]{\@basecount{arabic}{5}{\number #1}}
+\newcommand*{\@baseFive}[1]{\@basecount{}{5}{\number #1}}
 
 \newcommand*{\basicSymb}[1]{\expandafter\@basicSymb{\csname c@#1\endcsname}}
 \newcommand*{\@basicSymb}[1]{\@basecount{simpleSymbols}{7}{\number #1}}

--- a/page_numbering.tex
+++ b/page_numbering.tex
@@ -4,7 +4,8 @@
   \ifnum #3 = 0
     \csname @#1\endcsname{0}
   \else
-    \expandafter{}{\@@basecount{#1}{#2}{#3}{}}
+    \expandafter\edef\csname @baseResult\endcsname{\noexpand\@@basecount{#1}{#2}{#3}{}}
+    \csname @baseResult\endcsname
   \fi
 }
 
@@ -13,10 +14,9 @@
 \newcount\@@baseM
 \newcount\@@baseR
 \newcommand*{\@@basecount}[4]{% Syntax: \@@basecount{alphabet}{alphabet length}{counter}{accumulator}
-  \ifnum #3 = 0
-    #3--#4
-  \else{
-    #3--
+  \ifnum #3=0
+    #4
+  \else
     \@@baseQ #3
     \@@baseB #2
     \divide\@@baseQ by\@@baseB
@@ -24,9 +24,12 @@
     \multiply\@@baseM by\@@baseB
     \@@baseR #3
     \advance\@@baseR by-\@@baseM
-    \@@basecount{#1}{#2}{\the\@@baseQ}{\csname @#1\endcsname{\the\@@baseR}#4}
-  }\fi
+    \expandafter\edef\csname @@baseNext\endcsname{\the\@@baseQ}
+    \expandafter\edef\csname @@baseAcc\endcsname{\csname @#1\endcsname{\the\@@baseR}#4}
+    \@@basecount{#1}{#2}{\@@baseNext}{\@@baseAcc}
+  \fi
 }
+
 
 \newcommand*{\greekX}[1]{%
   \expandafter\@greekX{\csname c@#1\endcsname}

--- a/page_numbering.tex
+++ b/page_numbering.tex
@@ -32,12 +32,12 @@
 
 
 \newcommand*{\greekX}[1]{%
-  \expandafter\@greekX{\csname c@#1\endcsname}
+  \expandafter\@greekX{\csname c@#1\endcsname}%
 }
 
 
 \newcommand*{\@greekX}[1]{%
-  \@basecount{greek}{6}{\number #1}
+  \protect\protect\protect\@basecount{greek}{6}{\number #1}%
 }
 
 \newcommand*{\binaryX}[1]{%
@@ -59,18 +59,18 @@
 \newcommand*{\@hexX}[1]{0x\hex{#1}}
 
 \newcommand*{\greek}[1]{%
-  \expandafter\@greek\csname c@#1\endcsname
+  \expandafter\@greek\csname c@#1\endcsname%
 }
 
 \newcommand*{\@greek}[1]{%
-  $\ifcase#1
-  \alpha\or\beta\or\gamma\or\delta\or\varepsilon
-  \or\zeta\or\eta\or\theta\or\iota\or\kappa\or\lambda
-  \or\mu\or\nu\or\xi\or o\or\pi\or\rho\or\sigma
-  \or\tau\or\upsilon\or\varphi\or\chi\or\psi\or\omega
-  \or\text{\bfseries \ae}\or\text{\bfseries \o}\or\text{\bfseries \aa}
-  \or\mathfrak a\or\mathfrak b\or\mathfrak c\or\mathfrak d\or\mathfrak e
-  \else\@ctrerr\fi$
+  $\ifcase#1%
+  \alpha\or\beta\or\gamma\or\delta\or\varepsilon%
+  \or\zeta\or\eta\or\theta\or\iota\or\kappa\or\lambda%
+  \or\mu\or\nu\or\xi\or o\or\pi\or\rho\or\sigma%
+  \or\tau\or\upsilon\or\varphi\or\chi\or\psi\or\omega%
+  \or\text{\bfseries \ae}\or\text{\bfseries \o}\or\text{\bfseries \aa}%
+  \or\mathfrak a\or\mathfrak b\or\mathfrak c\or\mathfrak d\or\mathfrak e%
+  \else\@ctrerr\fi$%
 }
 
 

--- a/page_numbering.tex
+++ b/page_numbering.tex
@@ -1,12 +1,12 @@
 \makeatletter
 
-\newcommand*{\@basecount}[3]{% Syntax: \@basecount{alphabet}{alphabet length}{counter}
-  \ifnum #3 = 0
-    \csname @#1\endcsname{0}
-  \else
-    \expandafter\edef\csname @baseResult\endcsname{\noexpand\@@basecount{#1}{#2}{#3}{}}
-    \csname @baseResult\endcsname
-  \fi
+\DeclareRobustCommand{\@basecount}[3]{% Syntax: \@basecount{alphabet}{alphabet length}{counter}
+  \ifnum #3 = 0%
+    \csname @#1\endcsname{0}%
+  \else%
+    \expandafter\edef\csname @baseResult\endcsname{\noexpand\@@basecount{#1}{#2}{#3}{}}%
+    \csname @baseResult\endcsname%
+  \fi%
 }
 
 \newcount\@@baseQ
@@ -14,20 +14,20 @@
 \newcount\@@baseM
 \newcount\@@baseR
 \newcommand*{\@@basecount}[4]{% Syntax: \@@basecount{alphabet}{alphabet length}{counter}{accumulator}
-  \ifnum #3=0
-    #4
-  \else
-    \@@baseQ #3
-    \@@baseB #2
-    \divide\@@baseQ by\@@baseB
-    \@@baseM \@@baseQ
-    \multiply\@@baseM by\@@baseB
-    \@@baseR #3
-    \advance\@@baseR by-\@@baseM
-    \expandafter\edef\csname @@baseNext\endcsname{\the\@@baseQ}
-    \expandafter\edef\csname @@baseAcc\endcsname{\csname @#1\endcsname{\the\@@baseR}#4}
-    \@@basecount{#1}{#2}{\@@baseNext}{\@@baseAcc}
-  \fi
+  \ifnum #3=0%
+    #4%
+  \else%
+    \@@baseQ #3%
+    \@@baseB #2%
+    \divide\@@baseQ by\@@baseB%
+    \@@baseM \@@baseQ%
+    \multiply\@@baseM by\@@baseB%
+    \@@baseR #3%
+    \advance\@@baseR by-\@@baseM%
+    \expandafter\edef\csname @@baseNext\endcsname{\the\@@baseQ}%
+    \expandafter\edef\csname @@baseAcc\endcsname{\csname @#1\endcsname{\the\@@baseR}#4}%
+    \@@basecount{#1}{#2}{\@@baseNext}{\@@baseAcc}%
+  \fi%
 }
 
 
@@ -37,23 +37,23 @@
 
 
 \newcommand*{\@greekX}[1]{%
-  \protect\protect\protect\@basecount{greek}{6}{\number #1}%
+  \@basecount{greek}{24}{\number #1}%
 }
 
 \newcommand*{\binaryX}[1]{%
-  \expandafter\@binaryX\csname c@#1\endcsname
+  \expandafter\@binaryX\csname c@#1\endcsname%
 }
 
 \newcommand*{\@binaryX}[1]{0b\binary{#1}}
 
 \newcommand*{\octX}[1]{%
-  \expandafter\@octX\csname c@#1\endcsname
+  \expandafter\@octX\csname c@#1\endcsname%
 }
 
 \newcommand*{\@octX}[1]{0o\oct{#1}}
 
 \newcommand*{\hexX}[1]{%
-  \expandafter\@hexX\csname c@#1\endcsname
+  \expandafter\@hexX\csname c@#1\endcsname%
 }
 
 \newcommand*{\@hexX}[1]{0x\hex{#1}}
@@ -75,23 +75,23 @@
 
 
 \newcommand*{\symcount}[1]{%
-  \expandafter\@symcount\csname c@#1\endcsname
+  \expandafter\@symcount\csname c@#1\endcsname%
 }
 
 \newcommand*{\@symcount}[1]{%
-  $\ifcase#1
-  \neg\or\sqrt{\ }\or \int
-  \or +\or \times\or\pm\or \circ\or \oplus\or \otimes
-  \or\cup \or\cap%\or\sqcup\or\sqcap
-  \or \vert\or \Vert\or \perp%\or\angle
-  \or\sim
-  \or <\or >
-  \or =\or \cong
-  \or \in
-  \or\exists\or\forall\or \vee\or \wedge
-  \or\Rightarrow\or\mapsto\or\Leftrightarrow
-  \or\lightning\or\square
-  \else\@ctrerr\fi$
+  $\ifcase#1%
+  \neg\or\sqrt{\ }\or \int%
+  \or +\or \times\or\pm\or \circ\or \oplus\or \otimes%
+  \or\cup \or\cap%\or\sqcup\or\sqcap%
+  \or \vert\or \Vert\or \perp%\or\angle%
+  \or\sim%
+  \or <\or >%
+  \or =\or \cong%
+  \or \in%
+  \or\exists\or\forall\or \vee\or \wedge%
+  \or\Rightarrow\or\mapsto\or\Leftrightarrow%
+  \or\lightning\or\square%
+  \else\@ctrerr\fi$%
 }
 
 \makeatother

--- a/page_numbering.tex
+++ b/page_numbering.tex
@@ -1,5 +1,42 @@
 \makeatletter
 
+\newcommand*{\@basecount}[3]{% Syntax: \@basecount{alphabet}{alphabet length}{counter}
+  \ifnum #3 = 0
+    \csname @#1\endcsname{0}
+  \else
+    \expandafter{}{\@@basecount{#1}{#2}{#3}{}}
+  \fi
+}
+
+\newcount\@@baseQ
+\newcount\@@baseB
+\newcount\@@baseM
+\newcount\@@baseR
+\newcommand*{\@@basecount}[4]{% Syntax: \@@basecount{alphabet}{alphabet length}{counter}{accumulator}
+  \ifnum #3 = 0
+    #3--#4
+  \else{
+    #3--
+    \@@baseQ #3
+    \@@baseB #2
+    \divide\@@baseQ by\@@baseB
+    \@@baseM \@@baseQ
+    \multiply\@@baseM by\@@baseB
+    \@@baseR #3
+    \advance\@@baseR by-\@@baseM
+    \@@basecount{#1}{#2}{\the\@@baseQ}{\csname @#1\endcsname{\the\@@baseR}#4}
+  }\fi
+}
+
+\newcommand*{\greekX}[1]{%
+  \expandafter\@greekX{\csname c@#1\endcsname}
+}
+
+
+\newcommand*{\@greekX}[1]{%
+  \@basecount{greek}{6}{\number #1}
+}
+
 \newcommand*{\binaryX}[1]{%
   \expandafter\@binaryX\csname c@#1\endcsname
 }
@@ -24,7 +61,7 @@
 
 \newcommand*{\@greek}[1]{%
   $\ifcase#1
-  \or\alpha\or\beta\or\gamma\or\delta\or\varepsilon
+  \alpha\or\beta\or\gamma\or\delta\or\varepsilon
   \or\zeta\or\eta\or\theta\or\iota\or\kappa\or\lambda
   \or\mu\or\nu\or\xi\or o\or\pi\or\rho\or\sigma
   \or\tau\or\upsilon\or\varphi\or\chi\or\psi\or\omega

--- a/preamble.py
+++ b/preamble.py
@@ -66,6 +66,7 @@ def create_preamble(unf, camp, name, style, logo, empty):
 \\usepackage{stmaryrd}
 \\usepackage{amsmath}
 \\usepackage{amsthm}
+\\usepackage{calculator}
 \\usepackage[final]{pdfpages}
 \\usepackage[none]{hyphenat}
 \\usepackage{hyperref}

--- a/preamble.py
+++ b/preamble.py
@@ -66,7 +66,6 @@ def create_preamble(unf, camp, name, style, logo, empty):
 \\usepackage{stmaryrd}
 \\usepackage{amsmath}
 \\usepackage{amsthm}
-\\usepackage{calculator}
 \\usepackage[final]{pdfpages}
 \\usepackage[none]{hyphenat}
 \\usepackage{hyperref}


### PR DESCRIPTION
The general counting procedure is \@basecount

Implemented examples:
\greekX : Base 24 with the small greek letters
\baseFive : Usual numbers base 5
\basicSymb : Base 7 with the symbols =,+,-,\times,\div,<,>
